### PR TITLE
Update build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@
 # Based on the RaspberryPi Arch image from here:
 #  http://www.raspberrypi.org/downloads
 # specifically:
-#  http://downloads.raspberrypi.org/images/archlinuxarm/archlinux-hf-2012-09-18/archlinux-hf-2012-09-18.zip
+#  http://files.velocix.com/c1410/images/archlinuxarm/archlinux-hf-2012-09-18/archlinux-hf-2012-09-18.zip
 
 # PORTAL configuration overview
 #  


### PR DESCRIPTION
This is the first URL I pulled from the mirror list.  There are multiple available at the root page still, but keeping the original URL makes it harder to copy pasta & download with `wget`.  Propose to change to this URL in order to re-enable copy-pasta viability. :thumbsup:
