### PR TITLE
Minor updates

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -86,10 +86,16 @@ DataDirectory /var/lib/tor
 ## currently experimental.
 #ControlPort 9051
 
-VirtualAddrNetwork 10.192.0.0/10             
-AutomapHostsOnResolve 1                                              
-TransPort 172.16.0.1:9040                                                          
-DNSPort 172.16.0.1:9053                                                              
+## Map requests for .onion/.exit addresses to virtual addresses so
+## applications can resolve and connect to them transparently.
+AutomapHostsOnResolve 1 
+## Subnet to automap .onion/.exit address to.
+VirtualAddrNetworkIPv4 10.192.0.0/10
+
+## Open this port to listen for transparent proxy connections.
+TransPort 172.16.0.1:9040
+## Open this port to listen for UDP DNS requests, and resolve them anonymously.
+DNSPort 172.16.0.1:9053                                                               
 
 __TORRC__
 

--- a/build.sh
+++ b/build.sh
@@ -51,6 +51,8 @@ pacman -S polipo
 ## Setup the hardware random number generator
 echo "bcm2708-rng" > /etc/modules-load.d/bcm2708-rng.conf
 pacman -Sy rng-tools
+# Tell rngd to seed /dev/random using the hardware rng
+echo 'RNGD_OPTS="-o /dev/random -r /dev/hwrng"' > /etc/conf.d/rngd
 systemctl enable rngd
 
 # set the time to UTC, because that's how we roll

--- a/build.sh
+++ b/build.sh
@@ -157,15 +157,22 @@ systemctl enable ntp-wait.service
 
 # configure dnsmasq
 cat > /etc/dnsmasq.conf << __DNSMASQ__
+# Don't forward queries for private networks (i.e. 172.16.0.0/16) to upstream nameservers.
 bogus-priv
+# Don't forward queries for plain names (no dots or domain parts), to upstream nameservers.
+domain-needed
+# Ignore periodic Windows DNS requests which don't get sensible answers from the public DNS.
 filterwin2k
+
+# Listen for DNS queries arriving on this interface.
 interface=eth0
+# Bind to port 53 only on the interfaces listed above.
 bind-interfaces
 
-dhcp-range=172.16.0.50,172.16.0.150,12h
+# Serve DHCP replies in the following IP range
+dhcp-range=interface:eth0,172.16.0.50,172.16.0.150,255.255.255.0,12h
 
-# For debugging purposes, log each DNS query as it passes through
-# dnsmasq.
+# For debugging purposes, log each DNS query as it passes through dnsmasq.
 # XXX this is actually a good idea, particularly if you want to look for indicators of compromise.
 #log-queries
 __DNSMASQ__


### PR DESCRIPTION
* Added a config file for the rng daemon to seed `/dev/random` using `/dev/hwrng`. This may have already been the default behaviour if no config is specified, but it's probably best to specify it explicitly. ([per the Arch wiki](https://wiki.archlinux.org/index.php/Raspberry_Pi#Hardware_random_number_generator))
* Updated deprecated `VirtualAddrNetwork` option in torrc and added general documentation on the automapping options.
* Added `domain-needed` option and interface and subnet values for the `dhcp-range` option in dnsmasq, to (slightly) better prevent dns leaks and unintended dhcp replies.