### PR TITLE
Possible transproxy kernel leak

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -208,6 +208,7 @@ COMMIT
 -A INPUT -p tcp -j REJECT --reject-with tcp-reset
 -A INPUT -p udp -j REJECT --reject-with icmp-port-unreachable
 -A INPUT -j REJECT --reject-with icmp-proto-unreachable
+-A OUTPUT -m conntrack --ctstate INVALID -j DROP
 COMMIT
 # Completed on Thu Jan  1 01:24:22 1970 ## truf!
 __IPTABLES__


### PR DESCRIPTION
There is (was?) a bug in the kernel whereby transproxied packets whose connections are unexpectedly closed may send unproxied FIN ACK packets out as uid 0 in some circumstances ( [https://lists.torproject.org/pipermail/tor-talk/2014-March/032507.html](https://lists.torproject.org/pipermail/tor-talk/2014-March/032507.html) ):

> Basically, the bug happens when a transproxy connection shuts down
> completely before a client application properly closes the socket. This
> seems to cause the kernel to lose track of the fact that the client
> application connection was being transproxied, and when the client
> application finally does close its socket (or exits), the Linux kernel
> generates a FIN ACK that completely bypasses any transproxy rules you
> have installed. It sends this packet first as the UID of the app in
> question, and if that fails, it resends it as a blank UID (the kernel
> itself).

I added an iptables rule to explicitly drop outbound packets with an invalid state, which seems to be the cleanest way of preventing this behavior. I did not confirm the behavior is still present in newer kernels, but it seems prudent to include it as this could potentially jump even a physically isolated proxy.